### PR TITLE
MLP-11 implemented basic routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-hook-form": "^7.22.2",
         "react-router-dom": "^6.2.1",
@@ -4797,6 +4798,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4951,6 +4962,11 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-router": {
       "version": "6.2.1",
@@ -9983,6 +9999,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10084,6 +10110,11 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.22.2.tgz",
       "integrity": "sha512-gdz5dhdOPfd04uj00a+Fw8JHA4m6evn3RQeVEQSZCOrmRC+LqaTwsR97cQfj5vu3yCXhSETrUtiDoXJojW/KGg==",
       "requires": {}
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-router": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "webpack-dev-server": "^4.6.0"
   },
   "dependencies": {
+    "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-hook-form": "^7.22.2",
     "react-router-dom": "^6.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ import { useLocation } from "react-router-dom";
 const App = () => {
   const { userInfo } = useAuth();
   const location = useLocation();
-  console.log("userInfo", userInfo);
   return userInfo ? (
     <AuthorizedRoutes state={{ from: location }} />
   ) : (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,20 @@
 import React from "react";
 
+import UnAuthorizedRoute from "./UnAuthorizedRoutes/UnAuthorizedRoutes";
+import AuthorizedRoutes from "./AuthorizedRoutes/AuthorizedRoutes";
+import useAuth from "./hooks/Auth/useAuth";
+
+import { useLocation } from "react-router-dom";
+
 const App = () => {
-  return <div>Landing page</div>;
+  const { userInfo } = useAuth();
+  const location = useLocation();
+  console.log("userInfo", userInfo);
+  return userInfo ? (
+    <AuthorizedRoutes state={{ from: location }} />
+  ) : (
+    <UnAuthorizedRoute />
+  );
 };
 
 export default App;

--- a/src/AuthorizedRoutes/AuthorizedRoutes.jsx
+++ b/src/AuthorizedRoutes/AuthorizedRoutes.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
+
+import Memes from "./Memes/Memes";
+import MyMemes from "./MyMemes/MyMemes";
+import Meme from "./Meme/Meme";
+
+const AuthorizedRoutes = () => {
+  return (
+    <Routes>
+      <Route path="/memes" element={<Memes />} />
+      <Route path="/mymemes" element={<MyMemes />} />
+      <Route path="/mymemes:id" element={<Meme />} />
+      <Route path="*" element={<Memes />} />
+    </Routes>
+  );
+};
+
+export default AuthorizedRoutes;

--- a/src/AuthorizedRoutes/Meme/Meme.jsx
+++ b/src/AuthorizedRoutes/Meme/Meme.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Meme = () => {
+  return <div>Meme</div>;
+};
+
+export default Meme;

--- a/src/AuthorizedRoutes/Memes/Memes.jsx
+++ b/src/AuthorizedRoutes/Memes/Memes.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const Memes = () => {
+  return (
+    <div>
+      <p>Get your memes</p>
+    </div>
+  );
+};
+
+export default Memes;

--- a/src/AuthorizedRoutes/MyMemes/MyMemes.jsx
+++ b/src/AuthorizedRoutes/MyMemes/MyMemes.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const MyMemes = () => {
+  return <div>My Memes</div>;
+};
+
+export default MyMemes;

--- a/src/UnAuthorizedRoutes/ForgotPassword/ForgotPassword.jsx
+++ b/src/UnAuthorizedRoutes/ForgotPassword/ForgotPassword.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ForgotPassword = () => {
+  return <div>Forgot Pasword</div>;
+};
+
+export default ForgotPassword;

--- a/src/UnAuthorizedRoutes/Layout.jsx
+++ b/src/UnAuthorizedRoutes/Layout.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Outlet } from "react-router-dom";
+
+const propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const Layout = () => {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+};
+
+Layout.propTypes = propTypes;
+
+export default Layout;

--- a/src/UnAuthorizedRoutes/Layout.jsx
+++ b/src/UnAuthorizedRoutes/Layout.jsx
@@ -9,6 +9,7 @@ const propTypes = {
 const Layout = () => {
   return (
     <div>
+      {/* This is like a `children` in older version of react router */}
       <Outlet />
     </div>
   );

--- a/src/UnAuthorizedRoutes/Login/Login.jsx
+++ b/src/UnAuthorizedRoutes/Login/Login.jsx
@@ -5,21 +5,19 @@ const Login = () => {
   const { setUserInfo } = useAuth();
 
   return (
-    <div>
-      <ul>
-        <li>
-          <Link to="/memes" onClick={() => setUserInfo("user")}>
-            Login
-          </Link>
-        </li>
-        <li>
-          <Link to="/signup">Signup</Link>
-        </li>
-        <li>
-          <Link to="/forgot_password">Forgot password</Link>
-        </li>
-      </ul>
-    </div>
+    <ul>
+      <li>
+        <Link to="/memes" onClick={() => setUserInfo("user")}>
+          Login
+        </Link>
+      </li>
+      <li>
+        <Link to="/signup">Signup</Link>
+      </li>
+      <li>
+        <Link to="/forgot_password">Forgot password</Link>
+      </li>
+    </ul>
   );
 };
 

--- a/src/UnAuthorizedRoutes/Login/Login.jsx
+++ b/src/UnAuthorizedRoutes/Login/Login.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import useAuth from "../../hooks/Auth/useAuth";
+const Login = () => {
+  const { setUserInfo } = useAuth();
+
+  return (
+    <div>
+      <ul>
+        <li>
+          <Link to="/memes" onClick={() => setUserInfo("user")}>
+            Login
+          </Link>
+        </li>
+        <li>
+          <Link to="/signup">Signup</Link>
+        </li>
+        <li>
+          <Link to="/forgot_password">Forgot password</Link>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/UnAuthorizedRoutes/Signup/Signup.jsx
+++ b/src/UnAuthorizedRoutes/Signup/Signup.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Signup = () => {
+  return <div>Signup</div>;
+};
+
+export default Signup;

--- a/src/UnAuthorizedRoutes/UnAuthorizedRoutes.jsx
+++ b/src/UnAuthorizedRoutes/UnAuthorizedRoutes.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
+
+import Layout from "./Layout";
+import Login from "./Login/Login";
+import Signup from "./Signup/Signup";
+import ForgotPassword from "./ForgotPassword/ForgotPassword";
+
+const UnAuthorizedRoutes = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route path="signup/*" exact element={<Signup />} />
+      <Route exact path="/forgot_password" element={<ForgotPassword />} />
+      <Route path="*" element={<Navigate to="/" />} />
+    </Routes>
+  );
+};
+
+export default UnAuthorizedRoutes;

--- a/src/hooks/Auth/useAuth.jsx
+++ b/src/hooks/Auth/useAuth.jsx
@@ -1,0 +1,16 @@
+import React, { createContext, useContext, useState } from "react";
+
+const authContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [userInfo, setUserInfo] = useState();
+
+  const values = {
+    userInfo,
+    setUserInfo,
+  };
+
+  return <authContext.Provider value={values}>{children}</authContext.Provider>;
+};
+
+export default () => useContext(authContext);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./hooks/Auth/useAuth";
 import App from "./App";
 
 const root = document.getElementById("root");
 
-ReactDOM.render(<App />, root);
+ReactDOM.render(
+  <BrowserRouter>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </BrowserRouter>,
+  root
+);


### PR DESCRIPTION
## General
This PR implements basic router with react-router-dom v6 logic.

## New stuff from v5 to v6
- No more "Switch" component
Switch component replaces to Routes in v6.
- No more "Redirect" component
Replaced to Navigate
- Route cannot get children anymore
in v5, you can get children with wrapping them by Route, but from v6 cannot get children from that way.
You have to use "Outlet" component inside the Route component.

React router dom migration
https://reactrouter.com/docs/en/v6/upgrading/v5

## Related Jira ticket
https://private-side-project.atlassian.net/browse/MLP-11
