### PR TITLE
MLP-26/task/handle error response, shared UnAuthorizedForm component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "css-loader": "^6.5.1",
         "html-webpack-plugin": "^5.5.0",
         "react-dom": "^17.0.2",
+        "react-toastify": "^8.1.0",
         "sass-loader": "^12.4.0",
         "style-loader": "^3.3.1",
         "webpack": "^5.65.0",
@@ -2523,6 +2524,15 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5299,6 +5309,19 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "dev": true,
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/readable-stream": {
@@ -8637,6 +8660,12 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -10704,6 +10733,15 @@
       "requires": {
         "history": "^5.2.0",
         "react-router": "6.2.1"
+      }
+    },
+    "react-toastify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.1.0.tgz",
+      "integrity": "sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==",
+      "dev": true,
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "css-loader": "^6.5.1",
     "html-webpack-plugin": "^5.5.0",
     "react-dom": "^17.0.2",
+    "react-toastify": "^8.1.0",
     "sass-loader": "^12.4.0",
     "style-loader": "^3.3.1",
     "webpack": "^5.65.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ const App = () => {
   const cookie = document.cookie;
   const token = cookie.slice(cookie.indexOf("=") + 1);
   const location = useLocation();
+
   return token ? (
     <AuthorizedRoutes state={{ from: location }} />
   ) : (

--- a/src/UnAuthorizedRoutes/Login/Login.jsx
+++ b/src/UnAuthorizedRoutes/Login/Login.jsx
@@ -1,31 +1,13 @@
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { useForm, FormProvider } from "react-hook-form";
-import * as yup from "yup";
-
+import { useNavigate } from "react-router-dom";
+import UnAuthorizedForm from "components/UnAuthorizedForm/UnAuthorizedForm";
 import useLogin from "queries/useLogin";
-
-import Input from "components/Input/Input";
-
-import "./login.scss";
-
-const inputs = ["username", "password"];
 
 const Login = () => {
   const { loginMutation } = useLogin();
   const navigate = useNavigate();
 
-  const validationSchema = yup.object().shape({
-    username: yup.string().required(),
-    password: yup.string().required(),
-  });
-
-  const methods = useForm({
-    resolver: yupResolver(validationSchema),
-  });
-
-  const onSubmit = (data) => {
+  const onSubmit = (data, e) => {
     loginMutation(data).then((response) => {
       document.cookie = `token=${response.response}`;
       navigate("/memes", { replace: false });
@@ -34,30 +16,7 @@ const Login = () => {
 
   return (
     <div className="centering">
-      <FormProvider {...methods}>
-        <form
-          className="login-form-wrapper"
-          onSubmit={methods.handleSubmit(onSubmit)}
-        >
-          {inputs.map((input) => {
-            return (
-              <Input
-                key={input}
-                name={input}
-                label={input.toUpperCase()}
-                layout="column"
-              />
-            );
-          })}
-          <button type="submit" className="button mx-auto">
-            Less go...
-          </button>
-        </form>
-      </FormProvider>
-      <div className="login-links">
-        <Link to="/signup">Signup</Link>
-        <Link to="/forgot_password">Forgot password</Link>
-      </div>
+      <UnAuthorizedForm onSubmit={onSubmit} />
     </div>
   );
 };

--- a/src/UnAuthorizedRoutes/Signup/Signup.jsx
+++ b/src/UnAuthorizedRoutes/Signup/Signup.jsx
@@ -1,53 +1,19 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import { useForm, FormProvider } from "react-hook-form";
-import Input from "components/Input/Input";
 import useSignup from "queries/useSignup";
-import useLogin from "queries/useLogin";
-import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
-
-const inputs = ["username", "password"];
+import UnAuthorizedForm from "components/UnAuthorizedForm/UnAuthorizedForm";
 
 const Signup = () => {
   const { signupMutation } = useSignup();
-  const validationSchema = yup.object().shape({
-    username: yup.string().required(),
-    password: yup.string().required(),
-  });
 
-  const methods = useForm({
-    resolver: yupResolver(validationSchema),
-  });
   const onSignup = (data) => {
     signupMutation(data).then((res) => {
       console.log("res", res);
     });
   };
+
   return (
     <div className="centering">
-      <h3 className="title-font">Sign up</h3>
-      <FormProvider {...methods}>
-        <form
-          className="login-form-wrapper"
-          onSubmit={methods.handleSubmit(onSignup)}
-        >
-          {inputs.map((input) => {
-            return (
-              <Input
-                key={input}
-                name={input}
-                label={input.toUpperCase()}
-                layout="column"
-              />
-            );
-          })}
-          <button type="submit" className="button mx-auto">
-            Register
-          </button>
-        </form>
-      </FormProvider>
-      <Link to="/">Back</Link>
+      <UnAuthorizedForm onSubmit={onSignup} />
     </div>
   );
 };

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -23,7 +23,7 @@ const Input = ({ name, label, layout, inputType }) => {
       {label && <label className="title-font mb-2">{label}</label>}
       <input
         {...register(name)}
-        type="text"
+        type={inputType}
         className="base-font py-1 px-3"
         autoComplete={inputType === "text" ? "off" : "new-password"}
       />

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -11,16 +11,22 @@ const propTypes = {
   label: PropTypes.string,
   register: PropTypes.func,
   layout: PropTypes.string,
+  inputType: PropTypes.string,
 };
 
-const Input = ({ name, label, layout }) => {
-  const { register, formState } = useFormContext();
+const Input = ({ name, label, layout, inputType }) => {
+  const { register, formState, getValues } = useFormContext();
   const error = get(formState.errors, name);
 
   return (
     <div className={`input-container ${layout}`}>
       {label && <label className="title-font mb-2">{label}</label>}
-      <input {...register(name)} className="base-font py-1 px-3" />
+      <input
+        {...register(name)}
+        type="text"
+        className="base-font py-1 px-3"
+        autoComplete={inputType === "text" ? "off" : "new-password"}
+      />
       {error && <p className="error-font mb-0 mt-1">{error.message}</p>}
     </div>
   );

--- a/src/components/UnAuthorizedForm/UnAuthorizedForm.jsx
+++ b/src/components/UnAuthorizedForm/UnAuthorizedForm.jsx
@@ -20,6 +20,10 @@ const UnAuthorizedForm = ({ onSubmit }) => {
 
   const methods = useForm({
     resolver: yupResolver(validationSchema),
+    defaultValues: {
+      username: "",
+      password: "",
+    },
   });
 
   return (
@@ -37,6 +41,7 @@ const UnAuthorizedForm = ({ onSubmit }) => {
                 name={input}
                 label={input.toUpperCase()}
                 layout="column"
+                inputType={input === "username" ? "text" : "password"}
               />
             );
           })}

--- a/src/components/UnAuthorizedForm/UnAuthorizedForm.jsx
+++ b/src/components/UnAuthorizedForm/UnAuthorizedForm.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { useForm, FormProvider } from "react-hook-form";
+import Input from "components/Input/Input";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+
+import "./unAuthorizedForm.scss";
+
+const inputs = ["username", "password"];
+
+const UnAuthorizedForm = ({ onSubmit }) => {
+  const { pathname } = useLocation();
+  const isSignupPage = pathname === "/signup";
+
+  const validationSchema = yup.object().shape({
+    username: yup.string().required(),
+    password: yup.string().required(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(validationSchema),
+  });
+
+  return (
+    <div className="centering">
+      <h3 className="title-font">{isSignupPage ? "Sign up" : "Login"}</h3>
+      <FormProvider {...methods}>
+        <form
+          className="unAuthorizedForm-form-wrapper"
+          onSubmit={methods.handleSubmit(onSubmit)}
+        >
+          {inputs.map((input) => {
+            return (
+              <Input
+                key={input}
+                name={input}
+                label={input.toUpperCase()}
+                layout="column"
+              />
+            );
+          })}
+          <button type="submit" className="button mx-auto">
+            {isSignupPage ? "Register" : "Submit"}
+          </button>
+        </form>
+      </FormProvider>
+
+      {isSignupPage ? (
+        <Link to="/">Back</Link>
+      ) : (
+        <div className="unAuthorizedForm-links">
+          <Link to="/signup">Signup</Link>
+          <Link to="/forgot_password">Forgot password</Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UnAuthorizedForm;

--- a/src/components/UnAuthorizedForm/unAuthorizedForm.scss
+++ b/src/components/UnAuthorizedForm/unAuthorizedForm.scss
@@ -1,0 +1,16 @@
+@use "variables" as *;
+
+.unAuthorizedForm {
+  &-form-wrapper {
+    @include flexbox(column);
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  &-links {
+    color: white;
+    list-style-type: none;
+    @include flexbox;
+    gap: $spacing-lg;
+  }
+}

--- a/src/hooks/request/request.js
+++ b/src/hooks/request/request.js
@@ -1,4 +1,23 @@
 /**
+ * function `handleResponse` takes promise and resolve regardless response is error or not.
+ */
+
+const handleResponse = (res) => {
+  return new Promise((resolve, reject) => {
+    // gets body of response by res.json() which parse body text as JSON.
+    res.json().then((parsedData) => {
+      if (!res.ok) {
+        // return parsedData with reject to trigger `onError` in react-query
+        return reject(parsedData);
+      }
+
+      // return parsedData with resolve to trigger `onSuccess` in react-query
+      return resolve(parsedData);
+    });
+  });
+};
+
+/**
  * function `request` access meme_learner_api to mutate/query, and return response
  *
  * @param { string } uri
@@ -8,9 +27,7 @@
 
 export default async (uri, option) => {
   const baseUrl = "http://localhost:8090";
-  const response = await fetch(`${baseUrl}${uri}`, option)
-    .then((res) => res.json())
-    .then((data) => data);
+  const response = fetch(`${baseUrl}${uri}`, option).then(handleResponse);
 
   return response;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "./hooks/Auth/useAuth";
 import { QueryClientProvider, QueryClient } from "react-query";
+import { ToastContainer } from "react-toastify";
+import "!style-loader!css-loader!react-toastify/dist/ReactToastify.css";
 
 import App from "./App";
 
@@ -17,11 +19,24 @@ const queryClient = new QueryClient({
   },
 });
 
+const toastStyle = {
+  position: "top-right",
+  autoClose: 5000,
+  hideProgressBar: false,
+  newestOnTop: false,
+  closeOnClick: true,
+  rtl: false,
+  pauseOnFocusLoss: true,
+  draggable: false,
+  pauseOnHover: true,
+};
+
 ReactDOM.render(
   <QueryClientProvider client={queryClient}>
     <BrowserRouter>
       <AuthProvider>
         <App />
+        <ToastContainer {...toastStyle} />
       </AuthProvider>
     </BrowserRouter>
   </QueryClientProvider>,

--- a/src/queries/useLogin.js
+++ b/src/queries/useLogin.js
@@ -1,5 +1,6 @@
 import { useMutation } from "react-query";
 import request from "hooks/request/request";
+import { toast } from "react-toastify";
 
 const login = (variables) => {
   const response = request("/v1/login", {
@@ -9,16 +10,16 @@ const login = (variables) => {
     },
     body: JSON.stringify(variables),
   });
+
   return response;
 };
 
 export default () => {
   const { mutateAsync: loginMutation } = useMutation(login, {
-    onError: (err) => {
-      console.log("error", err.message);
-    },
-    onSuccess: (data) => {
-      console.log("success", data);
+    throwOnError: true,
+    onError: ({ error }) => {
+      toast.error(error.message);
+      return error;
     },
   });
 


### PR DESCRIPTION
## General
This PR implemented response error handler that toast message to let user know what kind of error occurred.

Besides, as commented on [here](https://github.com/private-side-project-org/meme_leaner/pull/8#discussion_r778502007), there is duplication between Login/Signup component, so create shared UnAuthorizedForm component and reuse it on both components.

## Learn about `fetchAPI`
While other library like `axios` handles error response as `reject` status, **the Promise returned from fetch() won’t reject on HTTP error status **.
`react-query` won't trigger `onError` if we just use fetch and get data without manually set error handling.
In this case, as MDN docs says, we should use `response.ok` after `fetch`, and handle how to resolve response depends on its status.
In my case, I created response handler which gets body of response first, then return body with `reject` or `resolve` depends on `response.ok`.(refer: src/hooks/request/request.js)


## Todos
- [x] create shared UnAuthorized component
- [x] remove duplicated field on Login and Signup, then apply UnAuthorized component.
- [x] installed react-toastify, and applied stylings
- [x] create response handler to give response with right status to react-query to let them trigger right handler.

## Related Jira ticket
https://private-side-project.atlassian.net/browse/MLP-26 

